### PR TITLE
highlighted relevant tags in search results

### DIFF
--- a/cms-force/src/app/components/content-finder-page/content-finder-page.component.html
+++ b/cms-force/src/app/components/content-finder-page/content-finder-page.component.html
@@ -107,6 +107,7 @@
                         <span
                            *ngFor="let link of content.links"
                            [style.background-color]=ms.subjectIdToModule.get(link.moduleId).color
+                           [style.font-weight]="(searchedSubjects.includes(ms.subjectIdToName.get(link.moduleId))) ? 'bold' : 'normal'"
                            class="tag-bubble">
                            {{ms.subjectIdToName.get(link.moduleId)}}
                            <!--Gets the subject's name from array of links in content-->

--- a/cms-force/src/app/components/content-finder-page/content-finder-page.component.ts
+++ b/cms-force/src/app/components/content-finder-page/content-finder-page.component.ts
@@ -22,6 +22,7 @@ export class ContentFinderPageComponent implements OnInit {
    moduleIDs: number[];
    selectedSubjects: string[] = [];  // selected from subject list
    // contentWrapper: ContentWrapper;
+   searchedSubjects: string[] = [];
 
    constructor(
       private cs: ContentFetcherService,
@@ -44,6 +45,7 @@ export class ContentFinderPageComponent implements OnInit {
       let filter: Filter = new Filter(
          this.title, this.selFormat, this.moduleIDs
       );
+      this.searchedSubjects = this.selectedSubjects;
       this.cs.filterContent(filter).subscribe(
          (response) => {
             if (response != null) {


### PR DESCRIPTION
Finder page component now remembers last submitted search subjects to bold relevant tags in results table.